### PR TITLE
[Feat] 회원가입 UI 구현

### DIFF
--- a/lib/data/blocs/signup/signup_bloc.dart
+++ b/lib/data/blocs/signup/signup_bloc.dart
@@ -44,7 +44,7 @@ class SignUpBloc extends Bloc<SignupEvent, SignUpState> {
     emit(state.copyWith(isSubmitting: true, isSuccess: false, isError: false, nickError: false));
     try {
       await userRepository.registerUser(
-        userNum: '1234',
+        userNum: state.userNum,
         nick: state.nick,
         age: state.age,
         gender: state.gender,

--- a/lib/data/blocs/signup/signup_bloc.dart
+++ b/lib/data/blocs/signup/signup_bloc.dart
@@ -1,0 +1,59 @@
+import 'package:bloc/bloc.dart';
+import 'signup_event.dart';
+import 'signup_state.dart';
+import 'package:chuck2wiz/data/repository/signup_repository.dart';
+
+class SignUpBloc extends Bloc<SignupEvent, SignUpState> {
+  final SignUpRepository userRepository;
+
+  SignUpBloc(this.userRepository) : super(const SignUpState()) {
+    on<UserNumChanged>(_onUserNumChanged);
+    on<NicknameChanged>(_onNicknameChanged);
+    on<AgeChanged>(_onAgeChanged);
+    on<GenderChanged>(_onGenderChanged);
+    on<JobChanged>(_onJobChanged);
+    on<FavoriteChanged>(_onFavoriteChanged);
+    on<FormSubmitted>(_onFormSubmitted);
+  }
+
+  void _onUserNumChanged(UserNumChanged event, Emitter<SignUpState> emit) {
+    emit(state.copyWith(userNum: event.userNum));
+  }
+
+  void _onNicknameChanged(NicknameChanged event, Emitter<SignUpState> emit) async {
+    emit(state.copyWith(nick: event.nickname, nickError: false));
+  }
+
+  void _onAgeChanged(AgeChanged event, Emitter<SignUpState> emit) {
+    emit(state.copyWith(age: event.age));
+  }
+
+  void _onGenderChanged(GenderChanged event, Emitter<SignUpState> emit) {
+    emit(state.copyWith(gender: event.gender));
+  }
+
+  void _onJobChanged(JobChanged event, Emitter<SignUpState> emit) {
+    emit(state.copyWith(job: event.job));
+  }
+
+  void _onFavoriteChanged(FavoriteChanged event, Emitter<SignUpState> emit) {
+    emit(state.copyWith(favorite: event.favorite));
+  }
+
+  Future<void> _onFormSubmitted(FormSubmitted event, Emitter<SignUpState> emit) async {
+    emit(state.copyWith(isSubmitting: true, isSuccess: false, isError: false, nickError: false));
+    try {
+      await userRepository.registerUser(
+        userNum: '1234',
+        nick: state.nick,
+        age: state.age,
+        gender: state.gender,
+        job: state.job,
+        favorite: state.favorite,
+      );
+      emit(state.copyWith(isSubmitting: false, isSuccess: true));
+    } catch (e) {
+      emit(state.copyWith(isSubmitting: false, isError: true, nickError: true));
+    }
+  }
+}

--- a/lib/data/blocs/signup/signup_event.dart
+++ b/lib/data/blocs/signup/signup_event.dart
@@ -1,0 +1,83 @@
+import 'package:equatable/equatable.dart';
+
+abstract class SignupEvent extends Equatable {
+  const SignupEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class UserNumChanged extends SignupEvent {
+  final String userNum;
+
+  const UserNumChanged(this.userNum);
+
+  @override
+  List<Object> get props => [userNum];
+}
+
+class NicknameChanged extends SignupEvent {
+  final String nickname;
+
+  const NicknameChanged(this.nickname);
+
+  @override
+  List<Object> get props => [nickname];
+}
+
+class AgeChanged extends SignupEvent {
+  final int age;
+
+  const AgeChanged(this.age);
+
+  @override
+  List<Object> get props => [age];
+}
+
+class GenderChanged extends SignupEvent {
+  final String gender;
+
+  const GenderChanged(this.gender);
+
+  @override
+  List<Object> get props => [gender];
+}
+
+class JobChanged extends SignupEvent {
+  final String job;
+
+  const JobChanged(this.job);
+
+  @override
+  List<Object> get props => [job];
+}
+
+class FavoriteChanged extends SignupEvent {
+  final List<String> favorite;
+
+  const FavoriteChanged(this.favorite);
+
+  @override
+  List<Object> get props => [favorite];
+}
+
+class FormSubmitted extends SignupEvent {
+  final String userNum;
+  final String nick;
+  final int age;
+  final String gender;
+  final String job;
+  final List<String> favorite;
+
+  const FormSubmitted({
+    required this.userNum,
+    required this.nick,
+    required this.age,
+    required this.gender,
+    required this.job,
+    required this.favorite,
+  });
+
+  @override
+  List<Object> get props => [userNum, nick, age, gender, job, favorite];
+}

--- a/lib/data/blocs/signup/signup_state.dart
+++ b/lib/data/blocs/signup/signup_state.dart
@@ -1,0 +1,76 @@
+import 'package:equatable/equatable.dart';
+
+class SignUpState extends Equatable {
+  const SignUpState({
+    this.userNum = '',
+    this.nick = '',
+    this.age = 0,
+    this.gender = '',
+    this.job = '',
+    this.favorite = const [],
+    this.nickError = false,
+    this.isSubmitting = false,
+    this.isSuccess = false,
+    this.isError = false,
+  });
+
+  final String userNum;
+  final String nick;
+  final int age;
+  final String gender;
+  final String job;
+  final List<String> favorite;
+  final bool nickError;
+  final bool isSubmitting;
+  final bool isSuccess;
+  final bool isError;
+
+  @override
+  List<Object?> get props => [
+    userNum,
+    nick,
+    age,
+    gender,
+    job,
+    favorite,
+    nickError,
+    isSubmitting,
+    isSuccess,
+    isError,
+  ];
+
+  SignUpState copyWith({
+    String? userNum,
+    String? nick,
+    int? age,
+    String? gender,
+    String? job,
+    List<String>? favorite,
+    bool? nickError,
+    bool? isSubmitting,
+    bool? isSuccess,
+    bool? isError,
+  }) {
+    return SignUpState(
+      userNum: userNum ?? this.userNum,
+      nick: nick ?? this.nick,
+      age: age ?? this.age,
+      gender: gender ?? this.gender,
+      job: job ?? this.job,
+      favorite: favorite ?? this.favorite,
+      nickError: nickError ?? this.nickError,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+      isSuccess: isSuccess ?? this.isSuccess,
+      isError: isError ?? this.isError,
+    );
+  }
+
+  bool get isValid {
+    return nick.isNotEmpty &&
+        age > 0 &&
+        gender.isNotEmpty &&
+        job.isNotEmpty &&
+        favorite.length <= 3 &&
+        !nickError;
+  }
+}

--- a/lib/data/repository/signup_repository.dart
+++ b/lib/data/repository/signup_repository.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+
+class SignUpRepository {
+  final String apiUrl = dotenv.env['API_URL']!;
+
+  Future<String> registerUser({
+    required String userNum,
+    required String nick,
+    required int age,
+    required String gender,
+    required String job,
+    required List<String> favorite,
+  }) async {
+
+    String serverGender;
+    if (gender == '남성') {
+      serverGender = 'MALE';
+    } else if (gender == '여성') {
+      serverGender = 'FEMALE';
+    } else {
+      serverGender = 'OTHER';
+    }
+
+    String serverJob;
+    if (job == '학생') {
+      serverJob = 'STUDENT';
+    } else if (job == '주부') {
+      serverJob = 'HOUSEWIFE';
+    } else if (job == '직장인') {
+      serverJob = 'WORKER';
+    } else if (job == '전문직') {
+      serverJob = 'PROFESSIONAL';
+    } else {
+      serverJob = 'OTHER';
+    }
+
+    final requestBody = {
+      'userNum': userNum,
+      'nick': nick,
+      'age': age,
+      'gender': serverGender, // 변환된 gender 값 사용
+      'job': serverJob,
+      'favorite': favorite,
+    };
+
+    try {
+      final response = await http.post(
+        Uri.parse(apiUrl),
+        headers: {'Content-Type': 'application/json'},
+        body: json.encode(requestBody),
+      ).timeout(Duration(seconds: 10));
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        print('Success SignUp: ${data['token']}');
+        return data['token'];
+      } else {
+        print('Failed to SignUp: ${response.statusCode} - ${response.body}');
+        throw Exception('Failed to SignUp: ${response.statusCode}');
+      }
+    } catch (e) {
+      print('Failed to SignUp: $e');
+      throw Exception('Failed to SignUp: $e');
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,7 @@ class MyApp extends StatelessWidget {
         ),
         GetPage(
             name: '/signUp',
-            page: () => const SignupPage(),
+            page: () => SignUpPage(),
         )
       ],
       theme: ThemeData(

--- a/lib/ui/define/color_defines.dart
+++ b/lib/ui/define/color_defines.dart
@@ -6,4 +6,5 @@ class ColorDefines {
   static const Color primaryBlack = Color(0xFF000000);
   static const Color primaryWhite = Color(0xFFFFFFFF);
   static const Color mainColor = Color(0xFF5D71BF);
+  static const Color primaryGray = Color(0xFFA9AABC);
 }

--- a/lib/ui/pages/signup_page.dart
+++ b/lib/ui/pages/signup_page.dart
@@ -1,17 +1,291 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../data/blocs/signup/signup_bloc.dart';
+import '../../data/blocs/signup/signup_event.dart';
+import '../../data/blocs/signup/signup_state.dart';
+import '../../ui/util/base_page.dart';
+import 'package:chuck2wiz/ui/define/color_defines.dart';
+import 'package:chuck2wiz/data/repository/signup_repository.dart';
+import 'package:chuck2wiz/ui/widget/favorite_dialog_widget.dart';
 
-class SignupPage extends StatelessWidget {
-  const SignupPage({super.key});
+class SignUpPage extends BasePage<SignUpBloc, SignUpState> {
+  static const double buttonHeight = 50.0;
+  static const double inputBorderRadius = 5.0;
+  static const TextStyle labelTextStyle = TextStyle(fontSize: 14);
+
+  const SignUpPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  SignUpBloc createBloc(BuildContext context) => SignUpBloc(SignUpRepository());
+
+  @override
+  Color get backgroundColor => ColorDefines.primaryWhite;
+
+  @override
+  Widget buildContent(BuildContext context, SignUpState state) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('회원가입'),
+        title: const Text('회원가입'),
+        centerTitle: true,
+        automaticallyImplyLeading: false,
       ),
-      body: Center(
-        child: Text('회원가입'),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    _buildNickField(context),
+                    verticalSpace(),
+                    _buildAgeField(context),
+                    verticalSpace(),
+                    _buildGenderField(context),
+                    verticalSpace(),
+                    _buildJobField(context),
+                    verticalSpace(),
+                    _buildFavoriteField(context),
+                  ],
+                ),
+              ),
+            ),
+            _buildSubmitButton(state, context),
+            verticalSpace(),
+          ],
+        ),
       ),
+    );
+  }
+
+  Widget verticalSpace([double height = 16.0]) => SizedBox(height: height);
+
+  Widget horizontalSpace([double width = 8.0]) => SizedBox(width: width);
+
+  Widget _buildNickField(BuildContext context) {
+    return BlocBuilder<SignUpBloc, SignUpState>(
+      builder: (context, state) {
+        return _buildFormField(
+          label: '닉네임',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                height: buttonHeight,
+                child: TextFormField(
+                  decoration: InputDecoration(
+                    hintText: '입력',
+                    suffixText: '${state.nick.length} / 10',
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(inputBorderRadius),
+                    ),
+                  ),
+                  initialValue: state.nick,
+                  onChanged: (value) => context.read<SignUpBloc>().add(NicknameChanged(value)),
+                ),
+              ),
+            ],
+          ),
+          errorText: state.nickError ? '중복된 닉네임입니다.' : null,
+        );
+      },
+    );
+  }
+
+
+  Widget _buildAgeField(BuildContext context) {
+    return BlocBuilder<SignUpBloc, SignUpState>(
+      builder: (context, state) {
+        return _buildFormField(
+          label: '나이',
+          child: SizedBox(
+            height: buttonHeight,
+            child: TextFormField(
+              decoration: InputDecoration(
+                hintText: '입력',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(inputBorderRadius),
+                ),
+              ),
+              initialValue: state.age.toString(),
+              keyboardType: TextInputType.number,
+              onChanged: (value) {
+                int? age = int.tryParse(value);
+                if (age != null) {
+                  context.read<SignUpBloc>().add(AgeChanged(age));
+                }
+              },
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildGenderField(BuildContext context) {
+    return BlocBuilder<SignUpBloc, SignUpState>(
+      builder: (context, state) {
+        return _buildFormField(
+          label: '성별',
+          child: Row(
+            children: [
+              _buildGenderButton(context, '남성', state.gender),
+              horizontalSpace(),
+              _buildGenderButton(context, '여성', state.gender),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildGenderButton(BuildContext context, String gender, String currentGender) {
+    final isSelected = gender == currentGender;
+    return Expanded(
+      child: SizedBox(
+        height: buttonHeight,
+        child: ElevatedButton(
+          onPressed: () => context.read<SignUpBloc>().add(GenderChanged(gender)),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: isSelected ? ColorDefines.mainColor : ColorDefines.primaryWhite,
+            foregroundColor: isSelected ? ColorDefines.primaryWhite : ColorDefines.primaryBlack,
+            side: BorderSide(color: isSelected ? ColorDefines.mainColor : ColorDefines.primaryGray),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(inputBorderRadius)),
+          ),
+          child: Text(gender),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildJobField(BuildContext context) {
+    return BlocBuilder<SignUpBloc, SignUpState>(
+      builder: (context, state) {
+        return _buildFormField(
+          label: '직업',
+          child: SizedBox(
+            height: buttonHeight,
+            child: DropdownButtonFormField<String>(
+              decoration: InputDecoration(
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(inputBorderRadius),
+                ),
+              ),
+              value: state.job.isEmpty ? null : state.job,
+              items: _buildJobItems(),
+              onChanged: (value) => context.read<SignUpBloc>().add(JobChanged(value!)),
+              validator: (value) => value == null ? '직업을 선택해주세요' : null,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  List<DropdownMenuItem<String>> _buildJobItems() {
+    const jobs = ['학생', '주부', '회사원', '전문가', '기타'];
+    return jobs.map((job) => DropdownMenuItem(
+      value: job,
+      child: Text(job, style: labelTextStyle, // 글씨 크기 설정
+      ),
+    )).toList();
+  }
+
+  Widget _buildFavoriteField(BuildContext context) {
+    return BlocBuilder<SignUpBloc, SignUpState>(
+      builder: (context, state) {
+        return _buildFormField(
+          label: '관심 분야 (최대 3개 선택 가능)',
+          child: SizedBox(
+            height: buttonHeight,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton(
+                onPressed: () async {
+                  final selectedFavorite = await showDialog<List<String>>(
+                    context: context,
+                    builder: (_) => FavoriteDialog(),
+                  );
+                  if (selectedFavorite != null) {
+                    context.read<SignUpBloc>().add(FavoriteChanged(selectedFavorite));
+                  }
+                },
+                style: TextButton.styleFrom(
+                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: 15),
+                  backgroundColor: Colors.transparent,
+                  side: BorderSide(color: ColorDefines.primaryGray),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(5)),
+                ),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    state.favorite.isEmpty ? '선택' : state.favorite.join(', '),
+                    style: TextStyle(color: ColorDefines.primaryBlack),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSubmitButton(SignUpState state, BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: buttonHeight,
+      child: ElevatedButton(
+        onPressed: state.isValid
+            ? () => context.read<SignUpBloc>().add(FormSubmitted(
+          userNum: state.userNum,
+          nick: state.nick,
+          age: state.age,
+          gender: state.gender,
+          job: state.job,
+          favorite: state.favorite,
+        ))
+            : null,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: state.isValid
+              ? ColorDefines.mainColor
+              : ColorDefines.primaryGray,
+          side: BorderSide(
+              color: state.isValid
+                  ? ColorDefines.mainColor
+                  : ColorDefines.primaryGray),
+          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 20),
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(inputBorderRadius)),
+        ),
+        child: const Text(
+          '완료',
+          style: TextStyle(
+              color: ColorDefines.primaryWhite,
+              fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFormField({
+    required String label,
+    required Widget child,
+    String? errorText,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: labelTextStyle),
+        verticalSpace(),
+        child,
+        if (errorText != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 4.0),
+            child: Text(errorText, style: const TextStyle(color: Colors.red)),
+          ),
+      ],
     );
   }
 }

--- a/lib/ui/widget/favorite_dialog_widget.dart
+++ b/lib/ui/widget/favorite_dialog_widget.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:chuck2wiz/ui/define/color_defines.dart';
+
+class FavoriteDialog extends StatefulWidget {
+  @override
+  _FavoriteDialogState createState() => _FavoriteDialogState();
+}
+
+class _FavoriteDialogState extends State<FavoriteDialog> {
+  final List<String> favorite = [
+    '분야1', '분야2', '분야3', '분야4',
+    '분야5', '분야6', '분야7', '분야8',
+    '분야9', '분야10', '분야11', '분야12',
+  ];
+
+  final List<String> selectedFavorite = [];
+
+  void _onFavoriteTap(String favorite) {
+    setState(() {
+      if (selectedFavorite.contains(favorite)) {
+        selectedFavorite.remove(favorite);
+      } else if (selectedFavorite.length < 3) {
+        selectedFavorite.add(favorite);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              '관심분야를 선택해주세요.\n(최대 3개 선택 가능)',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: favorite.map((favorite) {
+                final isSelected = selectedFavorite.contains(favorite);
+                return GestureDetector(
+                  onTap: () => _onFavoriteTap(favorite),
+                  child: _buildFavoriteChip(favorite, isSelected),
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                _buildActionButton(
+                  label: '취소',
+                  onPressed: () => Navigator.pop(context),
+                  backgroundColor: ColorDefines.primaryWhite,
+                  textColor: ColorDefines.primaryBlack,
+                ),
+                _buildActionButton(
+                  label: '확인',
+                  onPressed: selectedFavorite.isNotEmpty
+                      ? () => Navigator.pop(context, selectedFavorite)
+                      : null,
+                  backgroundColor: ColorDefines.mainColor,
+                  textColor: ColorDefines.primaryWhite,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFavoriteChip(String favorite, bool isSelected) {
+    return Container(
+      width: 70,
+      height: 30,
+      decoration: BoxDecoration(
+        color: ColorDefines.primaryWhite,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color: isSelected ? ColorDefines.mainColor : ColorDefines.primaryGray,
+        ),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        favorite,
+        style: TextStyle(
+          color: isSelected ? ColorDefines.mainColor : ColorDefines.primaryBlack,
+          fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActionButton({
+    required String label,
+    required VoidCallback? onPressed,
+    required Color backgroundColor,
+    required Color textColor,
+  }) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: backgroundColor,
+        foregroundColor: textColor,
+      ),
+      child: Text(label),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -208,6 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.6.6"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.6"
   http_parser:
     dependency: transitive
     description:
@@ -308,18 +316,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -356,18 +364,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   nested:
     dependency: transitive
     description:
@@ -545,10 +553,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -569,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   flutter_config: ^2.0.2
   flutter_dotenv: ^5.1.0
   flutter_naver_login: ^1.8.0
+  http: ^0.13.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**개발 내용**
- 회원가입 UI 구현
- 관심분야 다이얼로그 구현
- 서버 연결 
- 닉네임 중복체크 ('완료' 버튼을 누를 때 마다 중복 검사)

**앞으로의 과제**
- userId와 userNum의 연동
- 배경 색깔 문제 해결
- 확정된 관심 분야 반영

**사진**
<img width="360" alt="스크린샷 2024-09-28 오전 6 45 16" src="https://github.com/user-attachments/assets/cc7f67ef-28eb-47b8-8370-ec6827f1431f">

